### PR TITLE
Lighten dark comment color for readability

### DIFF
--- a/colors/vim-material.vim
+++ b/colors/vim-material.vim
@@ -17,7 +17,7 @@ let s:gui.foreground = { 'dark': '#EEFFFF', 'light': '#000000' }
 let s:gui.none       = { 'dark': 'NONE', 'light': 'NONE' }
 let s:gui.selection  = { 'dark': '#455A64', 'light': '#BCBCBC' }
 let s:gui.line       = { 'dark': '#212121', 'light': '#D0D0D0' }
-let s:gui.comment    = { 'dark': '#49656F', 'light': '#5F5F5F' }
+let s:gui.comment    = { 'dark': '#81B2C4', 'light': '#5F5F5F' }
 
 let s:gui.red          = { 'dark': '#FF5370', 'light': '#E53935' }
 let s:gui.dark_red     = { 'dark': '#B71C1C', 'light': '#E53935' }


### PR DESCRIPTION
I love this beautiful color scheme! But I find comments quite hard to read against the dark bg. Here's a change I made to make them a little lighter and easier on the eyes

Before
![screenshot from 2017-10-25 12-22-25](https://user-images.githubusercontent.com/564458/31996197-75349094-b97f-11e7-8b3f-b510822980d6.png)

After
![screenshot from 2017-10-25 12-21-39](https://user-images.githubusercontent.com/564458/31996194-71081b08-b97f-11e7-8aa2-479d19f3c9f2.png)